### PR TITLE
DAOSIBM-21 Rename ansible group_vars file to match role name

### DIFF
--- a/modules/daos_admin/templates/cloud-init.yaml.tftpl
+++ b/modules/daos_admin/templates/cloud-init.yaml.tftpl
@@ -158,7 +158,7 @@ write_files:
           net.ipv4.neigh.ens1.gc_stale_time: 2000000
           net.ipv4.neigh.ens1.base_reachable_time_ms: 120000
           net.ipv4.neigh.ens1.mcast_solicit: 18
-    path: /root/ansible-daos/group_vars/daos_servers/tuned
+    path: /root/ansible-daos/group_vars/daos_servers/tune
     owner: 'root:root'
     permissions: '0644'
   - content: |


### PR DESCRIPTION
Changed file name so that all variables for the "tune" role are be contained in a group_vars file with the same name as the role.

Signed-off-by: Mark Olson <115657904+mark-olson@users.noreply.github.com>