### PR TITLE
DAOSIBM-24: DAOS cluster creation bug fixes

### DIFF
--- a/modules/daos_admin/main.tf
+++ b/modules/daos_admin/main.tf
@@ -94,7 +94,7 @@ resource "ibm_is_instance" "daos_admin" {
   instance_template = ibm_is_instance_template.daos_admin.id
 
   boot_volume {
-    name = "${var.instance_base_name}-001-bv"
+    name = "${var.resource_prefix}-${var.instance_base_name}-001-bv"
   }
 }
 

--- a/modules/daos_server/data.tf
+++ b/modules/daos_server/data.tf
@@ -43,3 +43,7 @@ data "ibm_is_security_group" "daos_server" {
 data "ibm_is_security_groups" "daos_server" {
   vpc_name = var.vpc_name
 }
+
+data "ibm_is_image" "daos_baremetal_image" {
+  name = var.bare_metal_image_id
+}

--- a/modules/daos_server/server_bare_metal.tf
+++ b/modules/daos_server/server_bare_metal.tf
@@ -18,7 +18,7 @@ resource "ibm_is_bare_metal_server" "daos_server" {
   count = var.use_bare_metal ? var.instance_count : 0
   name  = format("%s-%03s", local.base_name, "${count.index + 1}")
 
-  image          = var.bare_metal_image_id
+  image          = data.ibm_is_image.daos_baremetal_image.id
   keys           = [for ssh_key in local.ssh_key_ids : ssh_key.id]
   profile        = var.instance_bare_metal_profile_name
   user_data      = local.user_data

--- a/modules/daos_server/server_bare_metal.tf
+++ b/modules/daos_server/server_bare_metal.tf
@@ -18,12 +18,14 @@ resource "ibm_is_bare_metal_server" "daos_server" {
   count = var.use_bare_metal ? var.instance_count : 0
   name  = format("%s-%03s", local.base_name, "${count.index + 1}")
 
-  image     = var.bare_metal_image_id
-  keys      = [for ssh_key in local.ssh_key_ids : ssh_key.id]
-  profile   = var.instance_bare_metal_profile_name
-  user_data = local.user_data
-  vpc       = data.ibm_is_vpc.daos_server.id
-  zone      = var.zone
+  image          = var.bare_metal_image_id
+  keys           = [for ssh_key in local.ssh_key_ids : ssh_key.id]
+  profile        = var.instance_bare_metal_profile_name
+  user_data      = local.user_data
+  vpc            = data.ibm_is_vpc.daos_server.id
+  zone           = var.zone
+  resource_group = data.ibm_resource_group.daos.id
+
 
   primary_network_interface {
     name                      = "eth0"

--- a/modules/daos_server/variables.tf
+++ b/modules/daos_server/variables.tf
@@ -99,7 +99,7 @@ variable "ssh_key_names" {
 # ibmcloud is images --visibility public | grep -v deprecated
 variable "bare_metal_image_id" {
   type    = string
-  default = "r006-d2a541d6-ceac-420d-a612-8ab43453f376" # ibm-redhat-8-6-minimal-amd64-3
+  default = "ibm-redhat-8-6-minimal-amd64-3"
 }
 
 variable "daos_admin_public_key" {


### PR DESCRIPTION
**Fixes for the below Scenarios :**

1. If we use a different Resource group then cluster creation is failing. Please refer to the error in the attached images.

2. Image not found for bare metal server creation in different regions.
3. When we have a cluster in the IBM cloud and we are trying to create one more DAOS cluster then we are getting “daos-admin-volume name already exists”.

**JIRA:** https://daosio.atlassian.net/browse/DAOSIBM-24